### PR TITLE
Fix settings type mismatch and boolean conversion

### DIFF
--- a/lib/settings/settings.source.ts
+++ b/lib/settings/settings.source.ts
@@ -38,7 +38,6 @@ export const getSettings = async () => {
   if (!result) return null;
   return convertIntegerValuesToBoolean(result, [
     "has_completed_tutorial",
-    "notification_sound",
     "notification_vibration",
   ]);
 };

--- a/lib/settings/settings.types.ts
+++ b/lib/settings/settings.types.ts
@@ -1,7 +1,7 @@
 export type Settings = {
   id: number;
   has_completed_tutorial: boolean;
-  notification_sound: boolean;
+  notification_sound: string | null;
   notification_vibration: boolean;
   theme: ThemeOption;
   language: string;

--- a/lib/utils/db-helpers.ts
+++ b/lib/utils/db-helpers.ts
@@ -89,9 +89,9 @@ export function convertIntegerValuesToBoolean<T extends { [key: string]: any }>(
   model: T,
   keys: (keyof T)[]
 ) {
-    for (const key of keys) {
-        (model[key] as boolean) = model[key] === 1
-    }
+  for (const key of keys) {
+    (model as any)[key] = model[key] === 1;
+  }
 
-    return model;
+  return model;
 }


### PR DESCRIPTION
## Summary
- fix `Settings` type for `notification_sound` to be a nullable string
- update settings retrieval to convert only boolean columns
- correct `convertIntegerValuesToBoolean` assignment logic

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6840c9c53398832bb9b391e5a4be1b66