### PR TITLE
Enable automatic iCloud backup of SQLite DB

### DIFF
--- a/lib/cloud/cloud.source.ts
+++ b/lib/cloud/cloud.source.ts
@@ -1,4 +1,4 @@
-import db from '../db';
+import { db } from '../db';
 import { TABLES } from './cloud.tables';
 
 export async function getTableData(table: string): Promise<any[]> {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,14 @@
 import * as SQLite from "expo-sqlite";
 
-const db = SQLite.openDatabaseSync("reminders.db");
+export let db = SQLite.openDatabaseSync("reminders.db");
+
+export async function reopenDatabase() {
+  try {
+    await db.closeAsync();
+  } catch {
+    // ignore close errors
+  }
+  db = SQLite.openDatabaseSync("reminders.db");
+}
+
 export default db;

--- a/lib/init/init.service.ts
+++ b/lib/init/init.service.ts
@@ -1,4 +1,4 @@
-import db from "../db";
+import { db } from "../db";
 import * as SQLite from "expo-sqlite";
 import { remindersInit } from "../reminders/reminders.service";
 import { notesInit } from "../notes/notes.service";

--- a/lib/notes/notes.source.ts
+++ b/lib/notes/notes.source.ts
@@ -1,4 +1,4 @@
-import db from "../db";
+import { db } from "../db";
 import { deleteFromTable } from "../utils/db-helpers";
 
 export async function notesInit() {

--- a/lib/notifications/notifications.source.ts
+++ b/lib/notifications/notifications.source.ts
@@ -1,4 +1,4 @@
-import db from "../db";
+import { db } from "../db";
 import { NReminder } from "../reminders/reminders.types";
 import {
   deleteFromTable,

--- a/lib/reminders/reminders.source.ts
+++ b/lib/reminders/reminders.source.ts
@@ -1,4 +1,4 @@
-import db from "../db";
+import { db } from "../db";
 import {
   deleteFromTable,
   insertIntoTable,

--- a/lib/schedules/schedules.source.ts
+++ b/lib/schedules/schedules.source.ts
@@ -1,4 +1,4 @@
-import db from "../db";
+import { db } from "../db";
 import {
   convertIntegerValuesToBoolean,
   deleteFromTable,

--- a/lib/settings/settings.source.ts
+++ b/lib/settings/settings.source.ts
@@ -1,5 +1,5 @@
 import { Settings } from "./settings.types";
-import db from "../db";
+import { db } from "../db";
 import {
   convertIntegerValuesToBoolean,
   updateTable,

--- a/lib/utils/db-helpers.ts
+++ b/lib/utils/db-helpers.ts
@@ -1,4 +1,5 @@
-import db from "../db";
+import { db } from "../db";
+import { syncDatabaseToCloud } from "../cloud/cloud.service";
 type GenericObject = { [key: string]: any };
 
 function formatBoolean(value: any) {
@@ -30,6 +31,9 @@ export async function insertIntoTable<T extends GenericObject>(
     `,
     modelKeys.map((k) => formatBoolean(model[k]))
   );
+
+  // Trigger cloud sync but don't block
+  syncDatabaseToCloud().catch(() => {});
 
   return result.lastInsertRowId;
 }
@@ -68,6 +72,8 @@ export async function updateTable<
       ...whereKeys.map((k) => formatBoolean(where[k])),
     ]
   );
+
+  syncDatabaseToCloud().catch(() => {});
 }
 
 export async function deleteFromTable<T extends GenericObject>(
@@ -83,6 +89,8 @@ export async function deleteFromTable<T extends GenericObject>(
     `,
     whereKeys.map((k) => formatBoolean(where[k]))
   );
+
+  syncDatabaseToCloud().catch(() => {});
 }
 
 export function convertIntegerValuesToBoolean<T extends { [key: string]: any }>(


### PR DESCRIPTION
## Summary
- sync database to cloud every time it mutates
- backup entire SQLite file instead of dumping JSON
- reopen DB when restoring from cloud

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*
- `npx tsc -p tsconfig.json` *(fails: various TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6842ebfb08dc832bbb9795cd20f9184c