### PR TITLE
Ensure Skia views unmount before reload

### DIFF
--- a/hooks/useConfetti.tsx
+++ b/hooks/useConfetti.tsx
@@ -1,17 +1,28 @@
 // ConfettiContext.tsx
-import React, { createContext, useRef, useContext } from "react";
+import React, { createContext, useRef, useContext, useState } from "react";
 import { Confetti, ConfettiMethods } from "react-native-fast-confetti";
 
-  const CONFETTI_COLORS = [
-    "#377EC0",
-    "#5460AC",
-    "#FBDF54",
-    "#12BAAA",
-    "#F7891F",
-    "#F04F52",
-  ];
+const CONFETTI_COLORS = [
+  "#377EC0",
+  "#5460AC",
+  "#FBDF54",
+  "#12BAAA",
+  "#F7891F",
+  "#F04F52",
+];
 
-const ConfettiContext = createContext<React.RefObject<ConfettiMethods> | null>(null);
+const ConfettiContext = createContext<React.RefObject<ConfettiMethods> | null>(
+  null
+);
+
+// function assigned by the provider to allow external teardown of the confetti
+// view. This enables consumers outside of React components (e.g. services)
+// to remove the Skia-based view before the runtime is destroyed.
+let teardownConfetti: (() => void) | null = null;
+
+export const destroyConfettiView = () => {
+  teardownConfetti?.();
+};
 
 export const useConfetti = () => {
   const context = useContext(ConfettiContext);
@@ -25,10 +36,20 @@ export const ConfettiProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const confettiRef = useRef<ConfettiMethods>(null);
+  const [visible, setVisible] = useState(true);
+
+  teardownConfetti = () => setVisible(false);
 
   return (
     <ConfettiContext.Provider value={confettiRef}>
-      <Confetti ref={confettiRef} colors={CONFETTI_COLORS} autoplay={false} fallDuration={6000} />
+      {visible && (
+        <Confetti
+          ref={confettiRef}
+          colors={CONFETTI_COLORS}
+          autoplay={false}
+          fallDuration={6000}
+        />
+      )}
       {children}
     </ConfettiContext.Provider>
   );

--- a/lib/backup/backup.service.ts
+++ b/lib/backup/backup.service.ts
@@ -5,6 +5,7 @@ import * as Updates from "expo-updates";
 import { Alert } from "react-native";
 import db, { DB_FILENAME } from "../db";
 import { BACKUP_FILENAME, SQLITE_DIR_NAME } from "./backup.constants";
+import { destroyConfettiView } from "@/hooks/useConfetti";
 
 const DB_DIR = FileSystem.documentDirectory + SQLITE_DIR_NAME;
 const DB_PATH = `${DB_DIR}/${DB_FILENAME}`;
@@ -112,6 +113,9 @@ export const restoreDatabase = async () => {
       {
         text: "OK",
         onPress: async () => {
+          destroyConfettiView();
+          // allow React to unmount the Skia view before reloading
+          await new Promise((r) => setTimeout(r, 50));
           await Updates.reloadAsync();
         },
       },


### PR DESCRIPTION
## Summary
- allow teardown of Confetti Skia view
- unmount Confetti view before calling `Updates.reloadAsync` when restoring backups

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d67a873bc832bad4de776caad4dbc