### PR TITLE
Replace Confetti ref with sendConfetti helper

### DIFF
--- a/app/welcome/index.tsx
+++ b/app/welcome/index.tsx
@@ -21,7 +21,7 @@ import omit from "lodash/omit";
 import { useEffect, useState } from "react";
 
 export default function () {
-  const confetti = useConfetti();
+  const sendConfetti = useConfetti();
   const { updateSettings, settings } = useSettings();
 
   const [pageState, setPageState] = useState(0);
@@ -55,10 +55,6 @@ export default function () {
     setPageState(1);
   }
 
-  function sendConfetti() {
-    confetti.current?.restart();
-    setTimeout(() => confetti.current?.reset(), 9000);
-  }
 
   async function completeReminder(reminder: Partial<InsertReminderModel>) {
     const scheduleIds: number[] = [];

--- a/components/reminder/ReminderDetails.tsx
+++ b/components/reminder/ReminderDetails.tsx
@@ -89,7 +89,7 @@ const ZodSchema = z.object({
 });
 
 export default function ({ reminder, onNotificationResponse }: Props) {
-  const confetti = useConfetti();
+  const sendConfetti = useConfetti();
   const router = useRouter();
 
   const [pastNotifications, setPastNotificatons] = useState<RNotification[]>(
@@ -181,10 +181,6 @@ export default function ({ reminder, onNotificationResponse }: Props) {
     setValue("is_muted", newVal.is_muted);
   });
 
-  function sendConfetti() {
-    confetti.current?.restart();
-    setTimeout(() => confetti.current?.reset(), 9000);
-  }
 
   async function handleNotificationAction(
     response: NotificationResponseStatus

--- a/components/reminder/ReminderSelectCard.tsx
+++ b/components/reminder/ReminderSelectCard.tsx
@@ -42,7 +42,7 @@ export default function ({
   displayOnly,
 }: Props) {
   const router = useRouter();
-  const confetti = useConfetti();
+  const sendConfetti = useConfetti();
 
   const { watch, setValue } = useForm({
     resolver: zodResolver(ZodSchema),
@@ -62,10 +62,6 @@ export default function ({
     setValue("is_muted", r.is_muted);
   });
 
-  function sendConfetti() {
-    confetti.current?.restart();
-    setTimeout(() => confetti.current?.reset(), 9000);
-  }
 
   async function handleNotificationAction(
     response: NotificationResponseStatus

--- a/hooks/useConfetti.tsx
+++ b/hooks/useConfetti.tsx
@@ -11,7 +11,7 @@ import { Confetti, ConfettiMethods } from "react-native-fast-confetti";
     "#F04F52",
   ];
 
-const ConfettiContext = createContext<React.RefObject<ConfettiMethods> | null>(null);
+const ConfettiContext = createContext<(() => void) | null>(null);
 
 export const useConfetti = () => {
   const context = useContext(ConfettiContext);
@@ -25,10 +25,26 @@ export const ConfettiProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const confettiRef = useRef<ConfettiMethods>(null);
+  const isFalling = useRef(false);
+
+  const sendConfetti = () => {
+    if (isFalling.current) return;
+    isFalling.current = true;
+    confettiRef.current?.restart();
+    setTimeout(() => {
+      confettiRef.current?.reset();
+      isFalling.current = false;
+    }, 9000);
+  };
 
   return (
-    <ConfettiContext.Provider value={confettiRef}>
-      <Confetti ref={confettiRef} colors={CONFETTI_COLORS} autoplay={false} fallDuration={6000} />
+    <ConfettiContext.Provider value={sendConfetti}>
+      <Confetti
+        ref={confettiRef}
+        colors={CONFETTI_COLORS}
+        autoplay={false}
+        fallDuration={6000}
+      />
       {children}
     </ConfettiContext.Provider>
   );


### PR DESCRIPTION
## Summary
- update `useConfetti` to return a `sendConfetti` function
- prevent duplicate confetti by ignoring calls while animation is running
- replace local `sendConfetti` implementations with the hook

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501fb61e74832b8ad47856f566fe85