### PR TITLE
Embed Quicksand fonts

### DIFF
--- a/app.json
+++ b/app.json
@@ -39,7 +39,19 @@
           }
         }
       ],
-      "expo-font",
+      [
+        "expo-font",
+        {
+          "fonts": [
+            "./assets/fonts/SpaceMono-Regular.ttf",
+            "./assets/fonts/Quicksand/Quicksand-Light.ttf",
+            "./assets/fonts/Quicksand/Quicksand-Regular.ttf",
+            "./assets/fonts/Quicksand/Quicksand-Medium.ttf",
+            "./assets/fonts/Quicksand/Quicksand-SemiBold.ttf",
+            "./assets/fonts/Quicksand/Quicksand-Bold.ttf"
+          ]
+        }
+      ],
       "expo-sqlite",
       "expo-dev-client",
        [

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout() {
   const route = useRouteInfo();
   useDrizzleStudio(db);
 
-  const [loaded] = useFonts({
+  const [loaded, error] = useFonts({
     SpaceMono: require("../assets/fonts/SpaceMono-Regular.ttf"),
     "Quicksand-Light": require("../assets/fonts/Quicksand/Quicksand-Light.ttf"),
     "Quicksand-Regular": require("../assets/fonts/Quicksand/Quicksand-Regular.ttf"),
@@ -68,10 +68,10 @@ export default function RootLayout() {
   }
 
   useEffect(() => {
-    if (loaded) {
+    if (loaded || error) {
       setupState();
     }
-  }, [loaded]);
+  }, [loaded, error]);
 
   useEffect(() => {
     Purchases.addCustomerInfoUpdateListener((info) => {


### PR DESCRIPTION
## Summary
- embed custom fonts in native build using expo-font config plugin
- handle font loading errors on startup

## Testing
- `npm test --silent -- -u` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856470aebdc832ba3ecf65cf1509148